### PR TITLE
Define bounds on both circle and rect for use with interfaces

### DIFF
--- a/circle.go
+++ b/circle.go
@@ -6,8 +6,8 @@ import (
 )
 
 // Circle is a 2D circle. It is defined by two properties:
-//  - Center vector
-//  - Radius float64
+//   - Center vector
+//   - Radius float64
 type Circle struct {
 	Center Vec
 	Radius float64
@@ -25,9 +25,9 @@ func C(center Vec, radius float64) Circle {
 
 // String returns the string representation of the Circle.
 //
-//  c := pixel.C(10.1234, pixel.ZV)
-//  c.String()     // returns "Circle(10.12, Vec(0, 0))"
-//  fmt.Println(c) // Circle(10.12, Vec(0, 0))
+//	c := pixel.C(10.1234, pixel.ZV)
+//	c.String()     // returns "Circle(10.12, Vec(0, 0))"
+//	fmt.Println(c) // Circle(10.12, Vec(0, 0))
 func (c Circle) String() string {
 	return fmt.Sprintf("Circle(%s, %.2f)", c.Center, c.Radius)
 }
@@ -46,6 +46,13 @@ func (c Circle) Norm() Circle {
 // Area returns the area of the Circle.
 func (c Circle) Area() float64 {
 	return math.Pi * math.Pow(c.Radius, 2)
+}
+
+func (c Circle) Bounds() Rect {
+	return Rect{
+		Min: V(c.Center.X-c.Radius, c.Center.Y-c.Radius),
+		Max: V(c.Center.X+c.Radius, c.Center.Y+c.Radius),
+	}
 }
 
 // Moved returns the Circle moved by the given vector delta.
@@ -169,8 +176,8 @@ func (c Circle) IntersectLine(l Line) Vec {
 // the perimeters touch.
 //
 // This function will return a non-zero vector if:
-//  - The Rect contains the Circle, partially or fully
-//  - The Circle contains the Rect, partially of fully
+//   - The Rect contains the Circle, partially or fully
+//   - The Circle contains the Rect, partially of fully
 func (c Circle) IntersectRect(r Rect) Vec {
 	// Checks if the c.Center is not in the diagonal quadrants of the rectangle
 	if (r.Min.X <= c.Center.X && c.Center.X <= r.Max.X) || (r.Min.Y <= c.Center.Y && c.Center.Y <= r.Max.Y) {

--- a/rectangle.go
+++ b/rectangle.go
@@ -29,9 +29,9 @@ func R(minX, minY, maxX, maxY float64) Rect {
 
 // String returns the string representation of the Rect.
 //
-//   r := pixel.R(100, 50, 200, 300)
-//   r.String()     // returns "Rect(100, 50, 200, 300)"
-//   fmt.Println(r) // Rect(100, 50, 200, 300)
+//	r := pixel.R(100, 50, 200, 300)
+//	r.String()     // returns "Rect(100, 50, 200, 300)"
+//	fmt.Println(r) // Rect(100, 50, 200, 300)
 func (r Rect) String() string {
 	return fmt.Sprintf("Rect(%v, %v, %v, %v)", r.Min.X, r.Min.Y, r.Max.X, r.Max.Y)
 }
@@ -68,6 +68,11 @@ func (r Rect) Size() Vec {
 // Area returns the area of r. If r is not normalized, area may be negative.
 func (r Rect) Area() float64 {
 	return r.W() * r.H()
+}
+
+// Bounds returns the bounding b ox for the rect (itself)
+func (r Rect) Bounds() Rect {
+	return r
 }
 
 // Edges will return the four lines which make up the edges of the rectangle.
@@ -158,9 +163,9 @@ func (r Rect) Moved(delta Vec) Rect {
 // Resized returns the Rect resized to the given size while keeping the position of the given
 // anchor.
 //
-//   r.Resized(r.Min, size)      // resizes while keeping the position of the lower-left corner
-//   r.Resized(r.Max, size)      // same with the top-right corner
-//   r.Resized(r.Center(), size) // resizes around the center
+//	r.Resized(r.Min, size)      // resizes while keeping the position of the lower-left corner
+//	r.Resized(r.Max, size)      // same with the top-right corner
+//	r.Resized(r.Center(), size) // resizes around the center
 //
 // This function does not make sense for resizing a rectangle of zero area and will panic. Use
 // ResizedMin in the case of zero area.
@@ -233,8 +238,8 @@ func (r Rect) Intersects(s Rect) bool {
 // the perimeters touch.
 //
 // This function will return a non-zero vector if:
-//  - The Rect contains the Circle, partially or fully
-//  - The Circle contains the Rect, partially of fully
+//   - The Rect contains the Circle, partially or fully
+//   - The Circle contains the Rect, partially of fully
 func (r Rect) IntersectCircle(c Circle) Vec {
 	return c.IntersectRect(r).Scaled(-1)
 }


### PR DESCRIPTION
In my project I have a basic Shape interface defined as

```
type Shape interface {
	Area() float64
	Bounds() pixel.Rect
	Contains(point pixel.Vec) bool
}
```

It would be super useful if the pixel shapes matched this interface. Rect of course would just return itself.

Working on a physics engine built on top of pixel (🤫), and I'm trying to keep to native pixel structs as much as possible. This would give me a lot of flexibility in working with them.

Not sure if it makes sense to add the interface itself to pixel or not, but I would certainly use it.